### PR TITLE
[FIXED JENKINS-28656] - On-demand creation of image fingerprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ This [Jenkins](http://jenkins-ci.org) plugin allows the tracking of the creation
       Web interfaces are being managed by common Jenkins Read permission
  * **Submit** - Allows the submission deployment records from the [remote API](#API)
  * **Delete** - Allows the deletion deployment records or entire fingerprints
-
-Currently, the plugin does not require additional configuration.
+4. Setup the Docker image fingerprint creation mode
+ * By default, the plugin does not create image fingerprints on its own. These fingerprints are expected to be created by other Docker plugins based on [Docker Commons][docker-commons]
+  * The behavior can be adjusted on the plugin's global configuration page
 
 ##Client-side configuration
 

--- a/src/main/java/org/jenkinsci/plugins/docker/traceability/DockerTraceabilityPluginConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/traceability/DockerTraceabilityPluginConfiguration.java
@@ -50,6 +50,14 @@ public class DockerTraceabilityPluginConfiguration implements Describable<Docker
         return DESCRIPTOR;
     }
 
+    /**
+     * Controls the behavior of {@link DockerTraceabilityPlugin} on missing parent images.
+     * If enabled, the plugin will create missing image fingerprints for all
+     * submitted reports, hence the plugin starts tracking containers being
+     * created for images without parent image fingerprints.
+     * @return true if {@link DockerTraceabilityPlugin} is allowed to create 
+     *      image fingerprints on-demand. false by default
+     */
     public boolean isCreateImageFingerprints() {
         return createImageFingerprints;
     }

--- a/src/main/java/org/jenkinsci/plugins/docker/traceability/DockerTraceabilityPluginConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/traceability/DockerTraceabilityPluginConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 Oleg Nenashev.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.docker.traceability;
+
+import hudson.Extension;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import javax.annotation.Nonnull;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Configuration of {@link DockerTraceabilityPlugin}.
+ * @author Oleg Nenashev
+ */
+public class DockerTraceabilityPluginConfiguration implements Describable<DockerTraceabilityPluginConfiguration> {
+    
+    private static final DockerTraceabilityPluginConfiguration DEFAULT = 
+            new DockerTraceabilityPluginConfiguration(false);
+            
+    private final boolean createImageFingerprints;
+
+    @DataBoundConstructor
+    public DockerTraceabilityPluginConfiguration(boolean createImageFingerprints) {
+        this.createImageFingerprints = createImageFingerprints;
+    }
+    
+    @Override
+    public Descriptor<DockerTraceabilityPluginConfiguration> getDescriptor() {
+        return DESCRIPTOR;
+    }
+
+    public boolean isCreateImageFingerprints() {
+        return createImageFingerprints;
+    }
+    
+    /**
+     * Gets the default configuration of {@link DockerTraceabilityPlugin}
+     * @return Default configuration
+     */
+    public static final @Nonnull DockerTraceabilityPluginConfiguration getDefault() {
+        return DEFAULT;
+    }
+    
+    @Extension
+    public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
+    
+    public static class DescriptorImpl extends Descriptor<DockerTraceabilityPluginConfiguration> {
+
+        @Override
+        public String getDisplayName() {
+            return "N/A";
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityHelper.java
@@ -131,7 +131,7 @@ public class DockerTraceabilityHelper {
         
         // TODO: this image is not protected from the fingerprint cleanup thread
         final Fingerprint fp = jenkins.getFingerprintMap().getOrCreate(
-                null, "Image "+(name != null ? name : name), getImageHash(imageId));
+                null, "Image "+(name != null ? name : imageId), getImageHash(imageId));
         return fp;
     }
     

--- a/src/main/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityHelper.java
@@ -115,6 +115,27 @@ public class DockerTraceabilityHelper {
     }
     
     /**
+     * Get or create a fingerprint by the specified image ID.
+     * @param imageId Full 64-symbol image id. Short forms are not supported.
+     * @param name Optional container name
+     * @param timestamp Timestamp if there is a need to create a new image
+     * @return Fingerprint. null if Jenkins has not been initialized yet
+     * @throws IOException Fingerprint loading error
+     */
+    public static @CheckForNull Fingerprint makeImage(@Nonnull String imageId, 
+            @CheckForNull String name, long timestamp) throws IOException {
+        final Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins == null) {
+            return null;
+        }
+        
+        // TODO: this image is not protected from the fingerprint cleanup thread
+        final Fingerprint fp = jenkins.getFingerprintMap().getOrCreate(
+                null, "Image "+(name != null ? name : name), getImageHash(imageId));
+        return fp;
+    }
+    
+    /**
      * Retrieves the last deployment record for the specified container.
      * @param containerId Container Id
      * @return Last registered record. Null if there is no data available

--- a/src/main/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityReportListenerImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityReportListenerImpl.java
@@ -55,18 +55,27 @@ public class DockerTraceabilityReportListenerImpl extends DockerTraceabilityRepo
         LOGGER.log(Level.FINE, "Got an event for image {0}", imageId);       
         
         try {
-            processEvent(report);
+            processReport(report);
         } catch (Throwable ex) { // Catch everything
             LOGGER.log(Level.WARNING, "Cannot retrieve the fingerprint", ex);
         } 
     }   
     
-    private void processEvent(@Nonnull DockerTraceabilityReport report) throws IOException {
+    private void processReport(@Nonnull DockerTraceabilityReport report) throws IOException {
+        DockerTraceabilityPlugin plugin = DockerTraceabilityPlugin.getInstance();
+
         // Get fingerprints for the image
-        final Fingerprint imageFP = DockerFingerprints.of(report.getImageId());
-        if (imageFP == null) {
-            LOGGER.log(Level.FINE, "Cannot find a fingerprint for image {0}. "
-                 + "Most probably, the image has not been created in Jenkins. Event will be ignored", report.getImageId());
+        Fingerprint imageFP = DockerFingerprints.of(report.getImageId());
+        if (imageFP == null && plugin.getConfiguration().isCreateImageFingerprints()) {
+            LOGGER.log(Level.FINE, "Creating a new fingerprint for image {0}", report.getImageId());
+            imageFP = DockerTraceabilityHelper.makeImage(report.getImageId(), 
+                    report.getImageName(), report.getEvent().getTime());
+        }
+        
+        if (imageFP == null) { // We don't create anything and exit
+            LOGGER.log(Level.FINE, "Cannot get or create a fingerprint for image {0}. "
+                + "Most probably, the image has not been created in Jenkins. Report will be ignored", 
+                    report.getImageId());
             return;
         }
                

--- a/src/main/resources/org/jenkinsci/plugins/docker/traceability/DockerTraceabilityPlugin/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/traceability/DockerTraceabilityPlugin/config.jelly
@@ -1,0 +1,34 @@
+<!--
+
+    The MIT License (MIT)
+
+    Copyright (c) 2015, CloudBees, Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" 
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:sl="/hudson/plugins/sidebar_link">
+  <f:section title="${%Docker Traceability}" description="${%Docker Traceability}">
+    <j:set var="instance" value="${it.configuration}" /> 
+    <j:set var="descriptor" value="${instance.descriptor}" />
+    <st:include from="${descriptor}" page="${descriptor.configPage}" optional="false" />
+  </f:section>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/docker/traceability/DockerTraceabilityPluginConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/traceability/DockerTraceabilityPluginConfiguration/config.jelly
@@ -1,0 +1,32 @@
+<!--
+
+    The MIT License (MIT)
+
+    Copyright (c) 2015, CloudBees, Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" 
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:sl="/hudson/plugins/sidebar_link">
+  <f:entry title="${%createImageFingerprints.title}" field="createImageFingerprints">
+        <f:checkbox checked="${it.createImageFingerprints}"/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/docker/traceability/DockerTraceabilityPluginConfiguration/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/docker/traceability/DockerTraceabilityPluginConfiguration/config.properties
@@ -1,0 +1,1 @@
+createImageFingerprints.title=Create image fingerprints on-demand

--- a/src/main/resources/org/jenkinsci/plugins/docker/traceability/DockerTraceabilityPluginConfiguration/help-createImageFingerprints.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/traceability/DockerTraceabilityPluginConfiguration/help-createImageFingerprints.html
@@ -1,0 +1,14 @@
+<div>
+  By default, the plugin registers traceability reports for images, which have
+  fingerprints registered by Jenkins plugins using the functionality from 
+  <a href="https://wiki.jenkins-ci.org/display/JENKINS/Docker+Commons+Plugin">
+    Docker Commons Plugin</a>. 
+    This behavior may may be an obstacle if a you want to trace fingerprints
+  for images created outside Jenkins or by plugins, which have no integration with
+  <a href="https://wiki.jenkins-ci.org/display/JENKINS/Docker+Commons+Plugin">
+    Docker Commons</a>.
+  <p/>
+  If enabled, Docker Traceability plugin will create image fingerprints for <b>all</b>
+  submitted reports, hence the plugin starts tracking containers being
+  created for images without parent image fingerprints.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/docker/traceability/DockerTraceabilityPluginTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/traceability/DockerTraceabilityPluginTest.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 Oleg Nenashev.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.docker.traceability;
+
+import java.io.IOException;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Stores tests for {@link DockerTraceabilityPlugin}.
+ * @author Oleg Nenashev
+ */
+public class DockerTraceabilityPluginTest {
+    
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    
+    @Test
+    public void testRoundTrip() throws Exception {
+        final DockerTraceabilityPlugin plugin = DockerTraceabilityPlugin.getInstance();
+        
+        // Default value
+        assertFalse(plugin.getConfiguration().isCreateImageFingerprints());
+        
+        // Round-trip with false
+        DockerTraceabilityPluginConfiguration falseConfig = new DockerTraceabilityPluginConfiguration(false);
+        plugin.configure(falseConfig);
+        assertFalse(plugin.getConfiguration().isCreateImageFingerprints());
+        plugin.load();
+        assertFalse(plugin.getConfiguration().isCreateImageFingerprints());
+        
+        // Round-trip with true
+        DockerTraceabilityPluginConfiguration trueConfig = new DockerTraceabilityPluginConfiguration(true);
+        plugin.configure(trueConfig);
+        assertTrue(plugin.getConfiguration().isCreateImageFingerprints());
+        plugin.load();
+        assertTrue(plugin.getConfiguration().isCreateImageFingerprints());
+    }
+    
+    /**
+     * Sets the plugin configuration.
+     * @param configuration Configuration to be set
+     * @throws IOException Save error
+     */
+    public static void configure(DockerTraceabilityPluginConfiguration configuration) 
+            throws IOException {
+        final DockerTraceabilityPlugin plugin = DockerTraceabilityPlugin.getInstance();
+        plugin.configure(configuration);
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityRootActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityRootActionTest.java
@@ -36,6 +36,9 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.docker.commons.fingerprint.DockerFingerprints;
+import org.jenkinsci.plugins.docker.traceability.DockerTraceabilityPlugin;
+import org.jenkinsci.plugins.docker.traceability.DockerTraceabilityPluginConfiguration;
+import org.jenkinsci.plugins.docker.traceability.DockerTraceabilityPluginTest;
 import org.jenkinsci.plugins.docker.traceability.fingerprint.DockerContainerRecord;
 import org.jenkinsci.plugins.docker.traceability.fingerprint.DockerDeploymentFacet;
 import org.jenkinsci.plugins.docker.traceability.fingerprint.DockerDeploymentRefFacet;
@@ -47,7 +50,9 @@ import org.jenkinsci.plugins.docker.traceability.util.FingerprintsHelper;
 import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.mockito.Mock;
@@ -103,6 +108,43 @@ public class DockerTraceabilityRootActionTest {
         ObjectMapper mapper= new ObjectMapper();
         final InspectContainerResponse[] parsedData = mapper.readValue(responseJSON, InspectContainerResponse[].class);
         assertEquals(1, parsedData.length);       
+    }
+    
+    @Test
+    @Bug(28656)
+    public void createFingerPrintsOnDemand() throws Exception {
+        // Read data from resources
+        String inspectData = JSONSamples.inspectContainerData.readString();
+        InspectContainerResponse inspectResponse = JSONSamples.inspectContainerData.
+                readObject(InspectContainerResponse[].class)[0];
+        final String containerId = inspectResponse.getId();
+        final String imageId = inspectResponse.getImageId();
+        
+        // Retrieve instances
+        final DockerTraceabilityRootAction action = DockerTraceabilityRootAction.getInstance();
+        assertNotNull(action);
+        
+        // Enable automatic fingerprints creation
+        DockerTraceabilityPluginConfiguration config = new DockerTraceabilityPluginConfiguration(true);
+        DockerTraceabilityPluginTest.configure(config);
+        DockerTraceabilityPlugin plugin = DockerTraceabilityPlugin.getInstance();
+        assertTrue(plugin.getConfiguration().isCreateImageFingerprints());
+        
+        // Submit JSON
+        HttpResponse res = action.doSubmitContainerStatus(inspectData, null, null, null, 0, null, null);
+        
+        // Ensure that both container and images have been created with proper facets
+        Fingerprint imageFP = DockerFingerprints.of(imageId);
+        Fingerprint containerFP = DockerFingerprints.of(containerId);
+        assertNotNull(imageFP);
+        assertNotNull(DockerFingerprints.getFacet(imageFP, DockerDeploymentRefFacet.class));
+        assertNotNull(containerFP);
+        assertNotNull(DockerFingerprints.getFacet(containerFP, DockerDeploymentFacet.class));
+        
+        // TODO: JENKINS-28655 (Fingerprints cleanup)
+        // Check original references - Docker Traceability Manager should create runs
+        // assertNotNull(imageFP.getOriginal().getJob());
+        // assertNotNull(containerFP.getOriginal().getJob());
     }
     
     /**


### PR DESCRIPTION
This change allows to configure Docker Traceability plugin to accept all submissions and create container/image fingerprints on-demand. This functionality is useful even if we don't support the fingerprints cleanup prevention now.

Problem:
* By default the plugin ignores report submissions if the container's base image fingerprint is not exist
* It blocks several cases
  * Track containers for images created by plugins, which have no integration with docker commons
  * Track containers for derivative images (e.g. we create petclinic image in Jenkins, then create a new image based on petclinic and launch it on Docker)
  * etc.

Proposed solution: A switch, which enables the creation of artificial image fingerprints ("created outside Jenkins") and saving of the data.

@reviewbybees @jtnord @rsandell 

P.S: The functionality has been picked from #9 . There was a partial review by @jtnord 
