### PR TITLE
[FIXED JENKINS-28658] - Create named container fingerprints

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityHelper.java
@@ -51,7 +51,6 @@ import org.jenkinsci.plugins.docker.traceability.util.FingerprintsHelper;
 public class DockerTraceabilityHelper {
     
     private final static Logger LOGGER = Logger.getLogger(DockerTraceabilityPlugin.class.getName());
-    private final static String CONTAINER_FP_NAME="<docker-container>";
     
     public static @Nonnull String getImageHash(@Nonnull String imageId) {
         return getFingerprintHash(imageId);
@@ -102,16 +101,21 @@ public class DockerTraceabilityHelper {
     /**
      * Get or create a fingerprint by the specified container ID.
      * @param containerId Full 64-symbol container id. Short forms are not supported.
+     * @param name Optional name of the container. If it is not available,
+     *      the container ID will be used to produce the name
      * @return Fingerprint. null if Jenkins has not been initialized yet
      * @throws IOException Fingerprint loading error
      */
-    public static @CheckForNull Fingerprint make(@Nonnull String containerId) throws IOException {
+    public static @CheckForNull Fingerprint make(@Nonnull String containerId, 
+            @CheckForNull String name) throws IOException {
         final Jenkins jenkins = Jenkins.getInstance();
         if (jenkins == null) {
             return null;
         }
         
-        return jenkins.getFingerprintMap().getOrCreate(null, CONTAINER_FP_NAME, getContainerHash(containerId));
+        return jenkins.getFingerprintMap().getOrCreate(null, 
+                "Container "+(name != null ? name : containerId), 
+                getContainerHash(containerId));
     }
     
     /**

--- a/src/main/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityReportListenerImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityReportListenerImpl.java
@@ -72,10 +72,11 @@ public class DockerTraceabilityReportListenerImpl extends DockerTraceabilityRepo
                
         // Update containerInfo if available
         final InspectContainerResponse containerInfo = report.getContainer();
-        @CheckForNull Fingerprint containerFP = null;
+        final @CheckForNull Fingerprint containerFP;
         if (containerInfo != null) {
             final String containerId = containerInfo.getId();
-            containerFP = DockerTraceabilityHelper.make(containerId);
+            final String containerName = hudson.Util.fixEmptyAndTrim(containerInfo.getName());
+            containerFP = DockerTraceabilityHelper.make(containerId, containerName);
             if (containerFP != null) {
                 DockerDeploymentFacet.addEvent(containerFP, report);
                 DockerDeploymentRefFacet.addRef(imageFP, containerInfo.getId());

--- a/src/main/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityReportListenerImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityReportListenerImpl.java
@@ -31,7 +31,6 @@ import hudson.model.Fingerprint;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.docker.commons.fingerprint.DockerFingerprints;
 import org.jenkinsci.plugins.docker.traceability.model.DockerTraceabilityReportListener;
@@ -72,11 +71,10 @@ public class DockerTraceabilityReportListenerImpl extends DockerTraceabilityRepo
                
         // Update containerInfo if available
         final InspectContainerResponse containerInfo = report.getContainer();
-        final @CheckForNull Fingerprint containerFP;
         if (containerInfo != null) {
             final String containerId = containerInfo.getId();
             final String containerName = hudson.Util.fixEmptyAndTrim(containerInfo.getName());
-            containerFP = DockerTraceabilityHelper.make(containerId, containerName);
+            final Fingerprint containerFP = DockerTraceabilityHelper.make(containerId, containerName);
             if (containerFP != null) {
                 DockerDeploymentFacet.addEvent(containerFP, report);
                 DockerDeploymentRefFacet.addRef(imageFP, containerInfo.getId());


### PR DESCRIPTION
The plugin will use container name if it is available. Otherwise it will fall-back to the container ID.

@reviewbybees