### PR TITLE
Constructor was missing the argumen for the ImageResponse.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityRootAction.java
@@ -261,7 +261,7 @@ public class DockerTraceabilityRootAction implements RootAction, SearchableModel
             DockerTraceabilityReport res = new DockerTraceabilityReport(event, hostInfo,
                     inspectContainerResponse, 
                     inspectContainerResponse.getImageId(), effectiveImageName,
-                    new LinkedList<String>(), effectiveEnvironment);
+                    /* InspectImageResponse */ null, new LinkedList<String>(), effectiveEnvironment);
             DockerTraceabilityReportListener.fire(res);
         }
         return HttpResponses.ok();

--- a/src/main/java/org/jenkinsci/plugins/docker/traceability/model/DockerTraceabilityReport.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/traceability/model/DockerTraceabilityReport.java
@@ -71,11 +71,13 @@ public class DockerTraceabilityReport {
     public DockerTraceabilityReport(@Nonnull Event event, @Nonnull Info hostInfo, 
             @CheckForNull InspectContainerResponse container, 
             @Nonnull String imageId, @CheckForNull String imageName, 
+            @CheckForNull InspectImageResponse image,
             @Nonnull List<String> parents, @CheckForNull String environment) {
         this.event = event;
         this.hostInfo = hostInfo;
         this.container = container;
         this.imageId = imageId;
+        this.image = image;
         this.parents = new ArrayList<String>(parents);
         this.imageName = imageName;
         this.environment = environment;


### PR DESCRIPTION
The Constructor was missing an argument and there was no setter for it, so add the argument to the constructor and fix callers.

Whilst this breaks backwards source (but not exposed API ) compatibility for clients we have only released betas so I do not consider this an issue, and even then they can keep using the old API version.

@reviewbybees