### PR TITLE
[FIXED JENKINS-28752] - Properly handle null imageIds

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityReportListenerImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityReportListenerImpl.java
@@ -92,6 +92,11 @@ public class DockerTraceabilityReportListenerImpl extends DockerTraceabilityRepo
                 return;
             }
         }
+        
+        if (imageId == null) { // Add the low-important warning
+            LOGGER.log(Level.FINE, "Cannot retrieve the imageId for container {0}. "
+                    + "Image fingerprints won't be created", report.getContainerId());
+        }
                
         // Update containerInfo if available
         final InspectContainerResponse containerInfo = report.getContainer();

--- a/src/main/java/org/jenkinsci/plugins/docker/traceability/fingerprint/DockerContainerRecord.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/traceability/fingerprint/DockerContainerRecord.java
@@ -62,8 +62,9 @@ public class DockerContainerRecord {
         return (container != null) ? DockerTraceabilityHelper.getContainerHash(container.getId()) : null;
     }
     
-    public @Nonnull String getImageFingerprintHash() {
-        return DockerTraceabilityHelper.getImageHash(report.getImageId());
+    public @CheckForNull String getImageFingerprintHash() {
+        final String imageId = report.getImageId();
+        return imageId != null ? DockerTraceabilityHelper.getImageHash(imageId) : null;
     }
     
     /**

--- a/src/main/java/org/jenkinsci/plugins/docker/traceability/fingerprint/DockerDeploymentFacet.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/traceability/fingerprint/DockerDeploymentFacet.java
@@ -31,8 +31,8 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import jenkins.model.FingerprintFacet;
 import org.jenkinsci.plugins.docker.commons.fingerprint.DockerFingerprintFacet;
+import org.jenkinsci.plugins.docker.commons.fingerprint.DockerFingerprints;
 import org.jenkinsci.plugins.docker.traceability.core.DockerTraceabilityHelper;
 import org.jenkinsci.plugins.docker.traceability.model.DockerEventType;
 import org.jenkinsci.plugins.docker.traceability.model.DockerTraceabilityReport;
@@ -46,7 +46,7 @@ import org.jenkinsci.plugins.docker.traceability.util.FingerprintsHelper;
  * @author Oleg Nenashev
  */
 public class DockerDeploymentFacet extends DockerFingerprintFacet {
-       
+        
     private final SortedSet<DockerContainerRecord> deploymentRecords 
             = new TreeSet<DockerContainerRecord>(new DockerContainerRecord.TimeComparator());
             
@@ -69,6 +69,22 @@ public class DockerDeploymentFacet extends DockerFingerprintFacet {
 
     public synchronized @CheckForNull DockerContainerRecord getLatest() {
         return (deploymentRecords.isEmpty()) ? null : deploymentRecords.last();
+    }
+
+    /**
+     * Get Image ID, for which the container has been created.
+     * This method is required, because the imageId may be missing in particular records.
+     * A common case - DIE event for a container with the deleted image.
+     * @return Commonly nonnull, but may be null in corner-cases
+     */
+    public synchronized @CheckForNull String getImageId() {
+        for (DockerContainerRecord record : deploymentRecords) {
+            String imageId = record.getReport().getImageId();
+            if (imageId != null) {
+                return imageId;
+            }
+        }
+        return null;
     }
     
     /**
@@ -107,11 +123,9 @@ public class DockerDeploymentFacet extends DockerFingerprintFacet {
     
     public static @Nonnull DockerDeploymentFacet getOrCreate(@Nonnull Fingerprint fingerprint)
             throws IOException {  
-        // Try to find an existing facet
-        for ( FingerprintFacet facet : fingerprint.getFacets()) {
-            if (facet instanceof DockerDeploymentFacet) {
-                return (DockerDeploymentFacet) facet;
-            }
+        DockerDeploymentFacet res = DockerFingerprints.getFacet(fingerprint, DockerDeploymentFacet.class);
+        if (res != null) {
+            return res;
         }
         
         // Create new one

--- a/src/main/java/org/jenkinsci/plugins/docker/traceability/fingerprint/DockerDeploymentFacet.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/traceability/fingerprint/DockerDeploymentFacet.java
@@ -75,7 +75,7 @@ public class DockerDeploymentFacet extends DockerFingerprintFacet {
      * Get Image ID, for which the container has been created.
      * This method is required, because the imageId may be missing in particular records.
      * A common case - DIE event for a container with the deleted image.
-     * @return Commonly nonnull, but may be null in corner-cases
+     * @return Commonly a {@code non-null} value, but may be {@code null} in corner-cases
      */
     public synchronized @CheckForNull String getImageId() {
         for (DockerContainerRecord record : deploymentRecords) {

--- a/src/main/java/org/jenkinsci/plugins/docker/traceability/model/DockerAPIReport.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/traceability/model/DockerAPIReport.java
@@ -74,9 +74,9 @@ public class DockerAPIReport {
     
     @ExportedBean
     public abstract static class Item {
-        private final String id;
-        private final String name;
-        private final String created;
+        private final @CheckForNull String id;
+        private final @CheckForNull String name;
+        private final @CheckForNull String created;
         private final @CheckForNull FingerprintRef fingerprint;
 
         public Item(String id, String name, String created, @CheckForNull Fingerprint fingerprint) {
@@ -369,12 +369,15 @@ public class DockerAPIReport {
             return null;
         }
         final DockerTraceabilityReport report = lastRecord.getReport();
+        final String imageId = report.getImageId();
         @CheckForNull Fingerprint imageFP = null;
-        try {
-            imageFP = DockerFingerprints.of(report.getImageId());
-        } catch (IOException ex) {
-            // Do nothing
-        } 
+        if (imageId != null) {
+            try {
+                imageFP = DockerFingerprints.of(imageId);
+            } catch (IOException ex) {
+                // Do nothing
+            } 
+        }
         
         final InspectImageResponse inspectImageResponse = report.getImage();
         final InspectContainerResponse inspectContainerResponse = report.getContainer();
@@ -382,7 +385,7 @@ public class DockerAPIReport {
             return null;
         }
         
-        final Image image = new Image(report.getImageId(), report.getImageName(), 
+        final Image image = new Image(imageId, report.getImageName(), 
                 (inspectImageResponse != null) ? inspectImageResponse.getCreated() : "N/A", imageFP);
         final State state = new State(lastStatus, inspectContainerResponse.getState());
         final Container container = new Container(inspectContainerResponse.getId(), inspectContainerResponse.getName(), 

--- a/src/main/java/org/jenkinsci/plugins/docker/traceability/model/DockerTraceabilityReport.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/traceability/model/DockerTraceabilityReport.java
@@ -40,16 +40,16 @@ import org.apache.commons.lang.StringUtils;
 public class DockerTraceabilityReport {
 
     @JsonProperty
-    private Event event;
+    private @Nonnull Event event;
     
     @JsonProperty
-    private Info hostInfo;
+    private @Nonnull Info hostInfo;
     
     @JsonProperty(required = false)
-    private InspectContainerResponse container;
+    private @CheckForNull InspectContainerResponse container;
     
     @JsonProperty(required = false)
-    private InspectImageResponse image;
+    private @CheckForNull InspectImageResponse image;
     
     @JsonProperty(required = false)
     private @CheckForNull String imageId;
@@ -61,7 +61,7 @@ public class DockerTraceabilityReport {
     private @CheckForNull String environment;
     
     @JsonProperty
-    private List<String> parents;
+    private @Nonnull List<String> parents;
       
     /**
      * Stub constructor for deserialization purposes.

--- a/src/main/java/org/jenkinsci/plugins/docker/traceability/model/DockerTraceabilityReport.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/traceability/model/DockerTraceabilityReport.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import org.apache.commons.lang.StringUtils;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class DockerTraceabilityReport {
@@ -50,8 +51,8 @@ public class DockerTraceabilityReport {
     @JsonProperty(required = false)
     private InspectImageResponse image;
     
-    @JsonProperty
-    private String imageId;
+    @JsonProperty(required = false)
+    private @CheckForNull String imageId;
     
     @JsonProperty(required = false)
     private @CheckForNull String imageName;
@@ -70,7 +71,7 @@ public class DockerTraceabilityReport {
     
     public DockerTraceabilityReport(@Nonnull Event event, @Nonnull Info hostInfo, 
             @CheckForNull InspectContainerResponse container, 
-            @Nonnull String imageId, @CheckForNull String imageName, 
+            @CheckForNull String imageId, @CheckForNull String imageName, 
             @CheckForNull InspectImageResponse image,
             @Nonnull List<String> parents, @CheckForNull String environment) {
         this.event = event;
@@ -116,8 +117,53 @@ public class DockerTraceabilityReport {
         return image;
     }
     
-    public @Nonnull String getImageId() {
-        return imageId;
+    /**
+     * Gets ID of the image.
+     * The method will try to retrieve the ID from several places in the report.
+     * @return Full 64-symbol IDs are supported. May be null in corner cases
+     * when the image info becomes deleted before the report submission.
+     */
+    public @CheckForNull String getImageId() {
+        if (imageId != null) {
+            return imageId;
+        }
+        
+        // Try InspectImageResponse
+        if (image != null) {
+            final String idFromImage = image.getId();
+            if (StringUtils.isNotBlank(idFromImage)) {
+                return idFromImage;
+            }
+        }
+        
+        // Try InspectContainerResponse
+        if (container != null) {
+            final String idFromContainer = container.getImageId();
+            if (StringUtils.isNotBlank(idFromContainer)) {
+                return idFromContainer;
+            }
+        }
+        
+        // TODO: Try extracting from event, which may have the data in some cases?
+        return null;
+    }
+    
+    /**
+     * Gets ID of the container.
+     * The method will try to retrieve the ID from several places in the report.
+     * @return Full 64-symbol IDs are supported. May be null if there is no 
+     * data in the request.
+     */
+    public @CheckForNull String getContainerId() {
+        if (container != null) {
+            final String idFromContainer = container.getId();
+            if (StringUtils.isNotBlank(idFromContainer)) {
+                return idFromContainer;
+            }
+        }
+        
+        // TODO: Try other possible sources like event?
+        return null;
     }
 
     /**

--- a/src/main/resources/org/jenkinsci/plugins/docker/traceability/fingerprint/DockerDeploymentFacet/main.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/traceability/fingerprint/DockerDeploymentFacet/main.jelly
@@ -44,7 +44,7 @@
     ${%Sources}
   </h3>
   <ul>  
-    <li>${%Base image}: <docker:image id="${report.imageId}"/></li>
+    <li>${%Base image}: <docker:image id="${it.imageId}"/></li>
     <li>${%Parent images}: <docker:parentImages parents="${report.parents}"/></li>
   </ul>
   

--- a/src/main/resources/org/jenkinsci/plugins/docker/traceability/lib/image.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/traceability/lib/image.groovy
@@ -26,6 +26,7 @@ import jenkins.model.Jenkins
 import hudson.model.Fingerprint
 import java.io.IOException
 import org.jenkinsci.plugins.docker.commons.fingerprint.DockerFingerprints
+import org.apache.commons.lang.StringUtils
 
 l=namespace(LayoutTagLib)
 t=namespace("/lib/hudson")
@@ -35,15 +36,17 @@ f=namespace("lib/form")
 st.documentation() {
     text("Renders image by its Id. The rendering relies on fingerprints.")
     st.attribute(name: "id", use: "required") {
-      text("Image Id. Only full 64-symbol IDs are supported") 
+      text("Image Id. Only full 64-symbol IDs are supported. Nulls will be processed as well") 
     }
 }
 
 Fingerprint fp = null;
-try {
-   fp = DockerFingerprints.of(id); 
-} catch (IOException ex) {
-    // Do nothing
+if (StringUtils.isNotBlank(id)) {
+  try {
+     fp = DockerFingerprints.of(id); 
+  } catch (IOException ex) {
+      // Do nothing
+  }
 }
 
 if (fp != null) {

--- a/src/test/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityReportListenerImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityReportListenerImplTest.java
@@ -1,0 +1,82 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.docker.traceability.core;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.model.Event;
+import java.util.LinkedList;
+import org.jenkinsci.plugins.docker.commons.fingerprint.DockerFingerprints;
+import org.jenkinsci.plugins.docker.traceability.DockerTraceabilityPluginConfiguration;
+import org.jenkinsci.plugins.docker.traceability.DockerTraceabilityPluginTest;
+import org.jenkinsci.plugins.docker.traceability.fingerprint.DockerDeploymentFacet;
+import org.jenkinsci.plugins.docker.traceability.model.DockerEvent;
+import org.jenkinsci.plugins.docker.traceability.model.DockerTraceabilityReport;
+import org.jenkinsci.plugins.docker.traceability.model.DockerTraceabilityReportListener;
+import org.jenkinsci.plugins.docker.traceability.samples.JSONSamples;
+import org.jenkinsci.plugins.docker.traceability.test.FingerprintTestUtil;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.Bug;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Tests for {@link DockerTraceabilityRootAction}.
+ * @author Oleg Nenashev
+ */
+public class DockerTraceabilityReportListenerImplTest {
+    
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    
+    /**
+     * Checks the resolution of imageId from previously saved data.
+     * @throws Exception test failure
+     */
+    @Bug(28752)
+    public void submitReportWithoutImageReference() throws Exception {
+        DockerTraceabilityPluginTest.configure(new DockerTraceabilityPluginConfiguration(true, true));
+        final String imageId = FingerprintTestUtil.generateDockerId("1");
+        final Event event1 = new DockerEvent("run", imageId, "host", 12345).toDockerEvent();
+        final Event event2 = new DockerEvent("die", imageId, "host", 12346).toDockerEvent();
+        final InspectContainerResponse containerInfo = JSONSamples.inspectContainerData_emptyImage.
+                readObject(InspectContainerResponse.class);
+        
+        DockerTraceabilityReport r1 = new DockerTraceabilityReport(event1, null, containerInfo, imageId, null, null, 
+                new LinkedList<String>(), null);
+        DockerTraceabilityReport r2 = new DockerTraceabilityReport(event2, null, containerInfo, null, null, null, 
+                new LinkedList<String>(), null);
+        
+        // Spawn two reports
+        DockerTraceabilityReportListener.fire(r1);
+        DockerTraceabilityReportListener.fire(r2);
+        
+        // Retrieve
+        final DockerDeploymentFacet facet = 
+            DockerFingerprints.getFacet(containerInfo.getId(), DockerDeploymentFacet.class);
+        assertNotNull(facet);
+        assertEquals(imageId, facet.getImageId());
+        assertEquals("Expected both reports to be saved in the fingerprint", 2, facet.getDeploymentRecords().size());     
+    }
+    
+}

--- a/src/test/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityRootActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/traceability/core/DockerTraceabilityRootActionTest.java
@@ -213,9 +213,9 @@ public class DockerTraceabilityRootActionTest {
         }    
         assertNotNull(action);
         
-        final String id1 = generateContainerId("1");
-        final String id2 = generateContainerId("2");
-        final String id3 = generateContainerId("3");
+        final String id1 = FingerprintTestUtil.generateDockerId("1");
+        final String id2 = FingerprintTestUtil.generateDockerId("2");
+        final String id3 = FingerprintTestUtil.generateDockerId("3");
         
         // Check consistency of create/update commands
         action.addContainerID(id1);
@@ -324,8 +324,5 @@ public class DockerTraceabilityRootActionTest {
         return inspectImageFacet;
     }
             
-    private @Nonnull String generateContainerId(@Nonnull String prefix) {
-        final String src = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
-        return prefix + StringUtils.substring(src, 0, 64-prefix.length());
-    }
+    
 }

--- a/src/test/java/org/jenkinsci/plugins/docker/traceability/samples/JSONSamples.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/traceability/samples/JSONSamples.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.docker.traceability.samples;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.io.InputStream;
 import org.apache.commons.io.IOUtils;
 
 /**
@@ -35,7 +36,15 @@ import org.apache.commons.io.IOUtils;
 public enum JSONSamples {
     
     inspectContainerData,
+    inspectContainerData_emptyImage,
     submitReport;
+
+    private JSONSamples() {
+        InputStream i = JSONSamples.class.getResourceAsStream(getFileName());
+        if (i == null) { // Fail the class initialization
+            throw new IllegalStateException("Cannot find resource " + getFileName());
+        }
+    }
     
     public String getFileName() {
         return this + ".json";

--- a/src/test/java/org/jenkinsci/plugins/docker/traceability/test/FingerprintTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/traceability/test/FingerprintTestUtil.java
@@ -28,8 +28,10 @@ import hudson.model.AbstractProject;
 import hudson.model.Fingerprint;
 import hudson.model.Run;
 import java.io.IOException;
+import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.docker.commons.fingerprint.DockerFingerprints;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -78,5 +80,15 @@ public class FingerprintTestUtil {
         
         DockerFingerprints.addFromFacet(null,imageId, latest);
         rsp.sendRedirect2(j.getRootUrl());
+    }
+    
+    /**
+     * Generates 64-symbol id with the specified prefix;
+     * @param prefix Prefix to be retrieved
+     * @return Generated ID (works for container and image).
+     */
+    public static @Nonnull String generateDockerId(@Nonnull String prefix) {
+        final String src = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+        return prefix + StringUtils.substring(src, 0, 64-prefix.length());
     }
 }

--- a/src/test/resources/org/jenkinsci/plugins/docker/traceability/samples/inspectContainerData_emptyImage.json
+++ b/src/test/resources/org/jenkinsci/plugins/docker/traceability/samples/inspectContainerData_emptyImage.json
@@ -1,0 +1,136 @@
+[{
+    "AppArmorProfile": "",
+    "Args": [
+        "-c",
+        "/var/lib/jenkins/run.sh"
+    ],
+    "Config": {
+        "AttachStderr": true,
+        "AttachStdin": true,
+        "AttachStdout": true,
+        "Cmd": [
+            "/bin/sh",
+            "-c",
+            "/var/lib/jenkins/run.sh"
+        ],
+        "CpuShares": 0,
+        "Cpuset": "",
+        "Domainname": "",
+        "Entrypoint": null,
+        "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        ],
+        "ExposedPorts": {
+            "22/tcp": {}
+        },
+        "Hostname": "469e5edd8d5b",
+        "Image": "jenkinsci/workflow-demo",
+        "Labels": {},
+        "MacAddress": "",
+        "Memory": 0,
+        "MemorySwap": 0,
+        "NetworkDisabled": false,
+        "OnBuild": null,
+        "OpenStdin": true,
+        "PortSpecs": null,
+        "StdinOnce": true,
+        "Tty": true,
+        "User": "",
+        "Volumes": null,
+        "WorkingDir": "/var/lib/jenkins/workflow-plugin-pipeline-demo"
+    },
+    "Created": "2015-04-29T11:55:42.968262967Z",
+    "Driver": "aufs",
+    "ExecDriver": "native-0.2",
+    "ExecIDs": null,
+    "HostConfig": {
+        "Binds": null,
+        "CapAdd": null,
+        "CapDrop": null,
+        "CgroupParent": "",
+        "ContainerIDFile": "",
+        "CpuShares": 0,
+        "CpusetCpus": "",
+        "Devices": [],
+        "Dns": null,
+        "DnsSearch": null,
+        "ExtraHosts": null,
+        "IpcMode": "",
+        "Links": null,
+        "LogConfig": {
+            "Config": null,
+            "Type": "json-file"
+        },
+        "LxcConf": [],
+        "Memory": 0,
+        "MemorySwap": 0,
+        "NetworkMode": "bridge",
+        "PidMode": "",
+        "PortBindings": {
+            "8080/tcp": [
+                {
+                    "HostIp": "",
+                    "HostPort": "8080"
+                }
+            ]
+        },
+        "Privileged": false,
+        "PublishAllPorts": false,
+        "ReadonlyRootfs": false,
+        "RestartPolicy": {
+            "MaximumRetryCount": 0,
+            "Name": ""
+        },
+        "SecurityOpt": null,
+        "Ulimits": null,
+        "VolumesFrom": null
+    },
+    "HostnamePath": "/mnt/sda1/var/lib/docker/containers/469e5edd8d5b33e3c905a7ffc97360ec6ee211d6782815fbcd144568045819e1/hostname",
+    "HostsPath": "/mnt/sda1/var/lib/docker/containers/469e5edd8d5b33e3c905a7ffc97360ec6ee211d6782815fbcd144568045819e1/hosts",
+    "Id": "469e5edd8d5b33e3c905a7ffc97360ec6ee211d6782815fbcd144568045819e1",
+    "Image": "",
+    "LogPath": "/mnt/sda1/var/lib/docker/containers/469e5edd8d5b33e3c905a7ffc97360ec6ee211d6782815fbcd144568045819e1/469e5edd8d5b33e3c905a7ffc97360ec6ee211d6782815fbcd144568045819e1-json.log",
+    "MountLabel": "",
+    "Name": "/desperate_babbage",
+    "NetworkSettings": {
+        "Bridge": "docker0",
+        "Gateway": "172.17.42.1",
+        "GlobalIPv6Address": "",
+        "GlobalIPv6PrefixLen": 0,
+        "IPAddress": "172.17.0.2",
+        "IPPrefixLen": 16,
+        "IPv6Gateway": "",
+        "LinkLocalIPv6Address": "fe80::42:acff:fe11:2",
+        "LinkLocalIPv6PrefixLen": 64,
+        "MacAddress": "02:42:ac:11:00:02",
+        "PortMapping": null,
+        "Ports": {
+            "22/tcp": null,
+            "8080/tcp": [
+                {
+                    "HostIp": "0.0.0.0",
+                    "HostPort": "8080"
+                }
+            ]
+        }
+    },
+    "Path": "/bin/sh",
+    "ProcessLabel": "",
+    "ResolvConfPath": "/mnt/sda1/var/lib/docker/containers/469e5edd8d5b33e3c905a7ffc97360ec6ee211d6782815fbcd144568045819e1/resolv.conf",
+    "RestartCount": 0,
+    "State": {
+        "Dead": false,
+        "Error": "",
+        "ExitCode": 0,
+        "FinishedAt": "0001-01-01T00:00:00Z",
+        "OOMKilled": false,
+        "Paused": false,
+        "Pid": 898,
+        "Restarting": false,
+        "Running": true,
+        "StartedAt": "2015-04-29T11:55:43.464717907Z"
+    },
+    "Volumes": {},
+    "VolumesRW": {}
+}
+]


### PR DESCRIPTION
This change provides multiple workarounds, which allow to restore imageId in submissions according to the report data and previous submissions for the container.

@reviewbybees @jtnord 