### PR TITLE
[WiP] [FIXED JENKINS-28933] - Exclude unrelocated docker-traceability-api from HPI

### DIFF
--- a/docker-traceability-plugin/pom.xml
+++ b/docker-traceability-plugin/pom.xml
@@ -101,6 +101,7 @@
           </dependencies>
           <configuration>
             <dependentWarExcludes>org.apache.httpcomponents:*,com.github.dockerjava*:*,com.google.guava*</dependentWarExcludes>
+            <warLibExcludes>docker-java-${docker-java.version}.jar,docker-traceability-api-${project.version}.jar</warLibExcludes>
             <archive>
               <manifestEntries>
                 <Mask-Classes>com.google.common</Mask-Classes>

--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,10 @@
 
   <properties>
     <maven-release-plugin.version>2.5.1</maven-release-plugin.version>
-    <hpi.plugin.version>1.112</hpi.plugin.version>
+    <hpi.plugin.version>1.114-SNAPSHOT</hpi.plugin.version>
     <stapler.version>1.207</stapler.version>
     <guava.version>18.0</guava.version>
+    <docker-java.version>1.3.0</docker-java.version>
     <jenkins.parent.version>${project.parent.version}</jenkins.parent.version>
     <jdk.debug>true</jdk.debug>
     <jdk.optimize>false</jdk.optimize>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-28933

Prevents the classloading bug. https://github.com/jenkinsci/maven-hpi-plugin/pull/18 merge&release is required to maintain the backward compatibility.

@reviewbybees
